### PR TITLE
Update translator.py

### DIFF
--- a/OpenTranslator/translator.py
+++ b/OpenTranslator/translator.py
@@ -146,8 +146,9 @@ class CustomTranslator:
             
             self.generate_audio(translated_text, Translation_chunk_output_path, target_language, input_path)
             
-            return translated_text
             self.unload_whisper_model()
+            return translated_text
+            
 
         except Exception as e:
             logging.error(f"Error processing audio: {e}")


### PR DESCRIPTION
Moved `unload_whisper_model` up, so it's called before `return`

## Summary by Sourcery

Bug Fixes:
- Move `unload_whisper_model` invocation ahead of the return in `process_audio_chunk` to guarantee the model is unloaded before exiting the function.